### PR TITLE
Update to new version.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -7,14 +7,14 @@ defmodule Ecs.Mixfile do
      elixir: "~> 1.2",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger]]
+    [extra_applications: [:logger, :crypto]]
   end
 
   # Dependencies can be Hex packages:


### PR DESCRIPTION
1.warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name;
2.warning: :crypto.strong_rand_bytes/1 defined in application :crypto is used by the current application but the current application does not directly depend on :crypto.